### PR TITLE
Add 'GitHub Skills' activity to activities database (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -57,6 +57,12 @@ activities = {
         "max_participants": 15,
         "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "TBD",
+        "max_participants": 25,
+        "participants": []
+    },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",


### PR DESCRIPTION
This pull request adds the "GitHub Skills" activity to the in-memory activities database, making it available for registration as described in issue #6. This addresses the urgent request to include the new GitHub Skills activity announced by the principal and ensures students can sign up for it like other activities.